### PR TITLE
fix: replicate model based on DOM elements

### DIFF
--- a/develop/index.js
+++ b/develop/index.js
@@ -3,14 +3,7 @@ import TwoWayDataBinding from '../src/index';
 const config = {
   attributeBind: `data-custom-bind`,
   attributeModel: `data-custom-model`,
-  dataModel: {
-    site: {
-      general: {
-        heading: `Heading added via JS`,
-        description: `Description added via JS`
-      }
-    }
-  }
+  dataModel: {}
 };
 
 const state = TwoWayDataBinding(config);

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -48,6 +48,24 @@ describe(`twoWayDataBinding`, () => {
     expect($element).toHaveTextContent(`Thor`);
   });
 
+  it(`Uses an empty object as dataModel`, () => {
+    const {
+      container,
+      bindName
+    } = render(
+      `<span data-bind="user.firstName">No JS User First Name</span>`,
+      `data-bind`
+      );
+
+    twoWayDataBinding({
+      $context: container,
+      dataModel: {}
+    });
+
+    const $element = bindName(`user.firstName`);
+    expect($element).toHaveTextContent(`No JS User First Name`);
+  });
+
   it(`Uses a custom pathDelimiter`, () => {
     const {
       container,

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -1,4 +1,9 @@
-import { isHTMLString, setValueByPath } from "../utils";
+import {
+  ensureArray,
+  getValueByPath,
+  isHTMLString,
+  setValueByPath
+} from "../utils";
 
 //
 // isHTMLString
@@ -58,5 +63,109 @@ describe(`setValueByPath`, () => {
     expect(object.a.aa).toEqual(value1);
     expect(object.a.b).toEqual(value2);
     expect(object.b.bb).toEqual(value3);
+  });
+});
+
+//
+// getValueByPath
+//
+describe(`getValueByPath`, () => {
+  test(`nested object`, () => {
+    const object = {
+      a: {
+        aa: 1,
+        ab: { aba: false },
+        ac: [0, 1]
+      },
+      b: true
+    };
+
+    expect(getValueByPath([`b`], object)).toEqual(true);
+    expect(getValueByPath([`a`, `aa`], object)).toEqual(1);
+    expect(getValueByPath([`a`, `ab`, `aba`], object)).toEqual(false);
+    expect(getValueByPath([`a`, `ac`, 1], object)).toEqual(1);
+    expect(getValueByPath([`c`, `a`], object)).toBeUndefined();
+  });
+
+  test(`should be correct with a fallback value`, () => {
+    expect(getValueByPath([`a`], {}, `fallback`)).toEqual(`fallback`);
+  });
+});
+
+//
+// ensureArray
+//
+describe(`ensureArray`, () => {
+  describe(`when called with an array`, () => {
+    test(`it should return the passed array`, () => {
+      const dummyArray = [1, 2, 3];
+      const returnedValue = ensureArray(dummyArray);
+
+      expect(Array.isArray(returnedValue)).toBe(true);
+      expect(returnedValue).toBe(dummyArray);
+    });
+  });
+
+  describe(`when called with a value that is undefined`, () => {
+    test(`it should return an empty array`, () => {
+      const returnedValue = ensureArray(undefined);
+
+      expect(Array.isArray(returnedValue)).toBe(true);
+      expect(returnedValue.length).toBe(0);
+    });
+  });
+
+  describe(`when called with a Nodelist`, () => {
+    test(`it should convert the Nodelist to an array`, () => {
+      const element1 = document.createElement(`div`);
+      const element2 = document.createElement(`div`);
+
+      document.body.appendChild(element1);
+      document.body.appendChild(element2);
+      const dummyNodelist = document.body.querySelectorAll(`div`);
+      const returnedValue = ensureArray(dummyNodelist);
+
+      expect(Array.isArray(returnedValue)).toBe(true);
+      expect(dummyNodelist[1]).toBe(returnedValue[1]);
+    });
+  });
+
+  describe(`when called with a value that that is not: array, undefined, or Nodelist`, () => {
+    test(`it should return an array that contains the passed value`, () => {
+      const dummyString = `string`;
+      const dummyNumber = 1;
+      const dummyBoolean = true;
+
+      /**
+       * @param {object} expectedArray
+       * @return {boolean}
+       */
+      function isSingleValueArray(expectedArray) {
+        return (Array.isArray(expectedArray) && expectedArray.length === 1);
+      }
+
+      /**
+       * @param {*} wrappedValue
+       * @param {*} value
+       * @return {boolean}
+       */
+      function areValuesOfMatchingType(wrappedValue, value) {
+        return (typeof wrappedValue[0] === typeof value);
+      }
+
+      /**
+       * @param {*} dummy
+       * @return {boolean}
+       */
+      function isValueWrappedInSingleArray(dummy) {
+        const returnValue = ensureArray(dummy);
+
+        return (isSingleValueArray(returnValue) && areValuesOfMatchingType(returnValue, dummy));
+      }
+
+      expect(isValueWrappedInSingleArray(dummyString)).toBe(true);
+      expect(isValueWrappedInSingleArray(dummyNumber)).toBe(true);
+      expect(isValueWrappedInSingleArray(dummyBoolean)).toBe(true);
+    });
   });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,7 +27,7 @@ export function isHTMLString(string) {
 
 /**
  * @param {*} value
- * @param {PropertyPath} path
+ * @param {string[]} path
  * @param {object} object
  * @return {*}
  */
@@ -50,4 +50,52 @@ export function setValueByPath(value, path, object) {
   setValueByPath(value, path, object[prop]);
 
   return object[prop];
+}
+
+/**
+ * @param {*} possibleArray
+ * @return {*[]}
+ */
+export function ensureArray(possibleArray) {
+  let array;
+
+  if (typeof possibleArray === `undefined`) {
+    return [];
+  }
+  if (possibleArray.constructor === Array) {
+    return possibleArray;
+  }
+  switch (possibleArray.constructor) {
+    case NodeList:
+      array = Array.prototype.slice.call(possibleArray);
+      break;
+    default:
+      array = [possibleArray];
+      break;
+  }
+
+  return array;
+}
+
+/**
+ * @param {string[]} path
+ * @param {object|array} object
+ * @param {*} [fallback]
+ * @return {*}
+ */
+export function getValueByPath(path, object, fallback) {
+  const reducer = (prev, curr) => {
+    if (prev && typeof prev === `object`) {
+      if (prev.constructor === Array) {
+        return prev[+curr];
+      }
+
+      return prev[curr];
+    }
+
+    return undefined;
+  };
+  const value = ensureArray(path).reduce(reducer, object);
+
+  return typeof value === `undefined` ? fallback : value;
 }


### PR DESCRIPTION
## Description
in case an empty dataModel is provided on JS initialisation, when assigning DOM references, assign the value they have in the static HTML.

It also avoids returning a Proxy for those objects that are DOMReferences. This allows to consume them in the application by querying them like `proxy.site.general.$heading`

## Types of changes

- [ ] Build update
- [ ] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added and/or updated the tests, when applicable
- [ ] I have added at least 1 reviewer to this PR (@quicoto or @rogercornet)
