### PR TITLE
fix: innerHTML-textContent when updating DOM

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ export default function(config) {
   function updateDOM($element, value) {
     if (typeof $element === `undefined` || value === null) return;
 
-    $element[propertyToGet($element)] = value;
+    $element[isHTMLString(value) ? `innerHTML` : `textContent`] = value;
   }
 
   /**

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -229,4 +229,24 @@ describe(`twoWayDataBinding`, () => {
     expect($input).toHaveValue(`Ricard`);
     expect(element).toHaveTextContent(`Ricard`);
   });
+
+  it(`Uses a one level object as dataModel with HTML`, () => {
+    const {
+      container,
+      bindName
+    } = render(
+      `<span data-bind="firstName"></span>`,
+      `data-bind`
+      );
+
+    twoWayDataBinding({
+      $context: container,
+      dataModel: {
+        firstName: `<span>Thor</span>`
+      }
+    });
+
+    const $element = bindName(`firstName`);
+    expect($element).toContainHTML(`<span>Thor</span>`);
+  });
 });


### PR DESCRIPTION
## Description
When updating the DOM from a value in the model, determine if innerHTML or textContent needs to be applied has to be done against the value of the property from the model instead of the innerHTML of the $element bound to that property

## Types of changes

- [ ] Build update
- [ ] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added and/or updated the tests, when applicable
- [x] I have added at least 1 reviewer to this PR (@quicoto or @rogercornet)
