### PR TITLE
fix: Allow multiple elements with the same data-bind attribute name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,10 @@ export default function(config) {
         .replace(lastprop, `${domRefPrefix}${lastprop}`)
         .split(pathDelimiter);
 
-      setValueByPath($ref, DOMRefPath, dataModel);
+      // Concat the possible value to have an array of elements
+      const $currentRef = getValueByPath(DOMRefPath, dataModel) || ``;
+
+      setValueByPath([$ref, ...$currentRef], DOMRefPath, dataModel);
 
       if (typeof getValueByPath([...propPath], dataModel) === `undefined`) {
         // Set the value that Element has in the static HTML in case is not
@@ -71,28 +74,31 @@ export default function(config) {
   }
 
   /**
-   * @param {HTMLElement} $element
+   * @param {HTMLElement[]} $elements
    * @param {string} value
    */
-  function updateDOM($element, value) {
-    if (typeof $element === `undefined` || value === null) return;
-    if ($element.tagName === `INPUT`) {
-      if ($element.type === `checkbox` || $element.type === `radio`) {
-        let checked = value;
+  function updateDOM($elements, value) {
+    if (typeof $elements === `undefined` || value === null) return;
 
-        // Make sure we're setting a boolean
-        if (typeof checked !== `boolean`) {
-          // Convert string to boolean
-          checked = value.toLowerCase() === `true` ? true : false;
+    $elements.forEach(($element) => {
+      if ($element.tagName === `INPUT`) {
+        if ($element.type === `checkbox` || $element.type === `radio`) {
+          let checked = value;
+
+          // Make sure we're setting a boolean
+          if (typeof checked !== `boolean`) {
+            // Convert string to boolean
+            checked = value.toLowerCase() === `true` ? true : false;
+          }
+
+          $element.checked = checked;
+        } else {
+          $element.value = value;
         }
-
-        $element.checked = checked;
       } else {
-        $element.value = value;
+        $element[isHTMLString(value) ? `innerHTML` : `textContent`] = value;
       }
-    } else {
-      $element[isHTMLString(value) ? `innerHTML` : `textContent`] = value;
-    }
+    });
   }
 
   /**
@@ -105,7 +111,7 @@ export default function(config) {
    */
   function iterateDataModelAndUpdateDOM(data) {
     for (const key in data) {
-      if (isHTMLElement(data[key])) {
+      if (Array.isArray(data[key]) && data[key]?.every(($el) => isHTMLElement($el))) {
         updateDOM(data[key], data[key.replace(domRefPrefix, ``)]);
       } else if (typeof data[key] === `object` && data[key] !== null) {
         iterateDataModelAndUpdateDOM(data[key]);

--- a/src/tests/helpers/test-utils.js
+++ b/src/tests/helpers/test-utils.js
@@ -5,6 +5,8 @@ function render(html, attributeBind) {
   container.innerHTML = html;
   const bindName = (testId, attribute) =>
     container.querySelector(`[${attribute ? attribute : attributeBind}="${testId}"]`);
+  const bindNames = (testId, attribute) =>
+    container.querySelectorAll(`[${attribute ? attribute : attributeBind}="${testId}"]`);
   // asFragment has been stolen from react-testing-library
   const asFragment = () =>
     document.createRange().createContextualFragment(container.innerHTML);
@@ -14,7 +16,7 @@ function render(html, attributeBind) {
   document.body.innerHTML = ``;
   document.body.appendChild(container);
 
-  return {container, bindName, asFragment};
+  return {container, bindName, bindNames, asFragment};
 }
 
 export {render};

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -443,6 +443,30 @@ describe(`twoWayDataBinding`, () => {
     expect($element).toHaveTextContent(`This is a long text`);
   });
 
+  it(`2 elements with same bind path`, () => {
+    const {
+      container,
+      bindNames
+    } = render(
+      `<p data-bind="myDescription"></p>
+       <p data-bind="myDescription"></p>`,
+      `data-bind`
+      );
+
+    twoWayDataBinding({
+      $context: container,
+      dataModel: {
+        myDescription: `Two elements with same description`
+      }
+    });
+
+    const $elements = bindNames(`myDescription`);
+
+    $elements.forEach(($element) => {
+      expect($element).toHaveTextContent(`Two elements with same description`);
+    });
+  });
+
   it(`Textarea with model`, () => {
     const {
       container,


### PR DESCRIPTION
## Description
Store DOM references as an Array of elements in order to allow having multiple elements with the same path defined in the data-bind attribute

## Types of changes

- [ ] Build update
- [ ] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ ] I have added and/or updated the tests, when applicable
- [ ] I have added at least 1 reviewer to this PR (@quicoto or @rogercornet)
