### PR TITLE
bugfix: use last occurrence of the last prop to store DOM ref

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ export default (config = {}) => {
       const lastprop = [...propPath].pop();
       // Set the DOM Reference with the same name of the data-bind attribute with domRefPrefix ($)
       const DOMRefPath = propPathString
-        .replace(lastprop, `${domRefPrefix}${lastprop}`)
+        .replace(new RegExp(`${lastprop}$`), `${domRefPrefix}${lastprop}`)
         .split(pathDelimiter);
 
       // Concat the possible value to have an array of elements

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import {
-  getValueByPath, isHTMLElement, isHTMLString, setValueByPath
+  extend, getValueByPath, isHTMLElement, isHTMLString, isObject, setValueByPath
 } from "./utils";
 
 /**
@@ -156,7 +156,11 @@ export default (config = {}) => {
         return data[prop];
       },
       set: (data, prop, value) => {
-        data[prop] = value;
+        if (isObject(value)) {
+          data[prop] = extend(data[prop], value);
+        } else {
+          data[prop] = value;
+        }
 
         /**
          * At this point:

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -1,7 +1,9 @@
 import {
   ensureArray,
+  extend,
   getValueByPath,
   isHTMLString,
+  isObject,
   setValueByPath
 } from "../utils";
 
@@ -166,5 +168,43 @@ describe(`ensureArray`, () => {
       expect(isValueWrappedInSingleArray(dummyNumber)).toBe(true);
       expect(isValueWrappedInSingleArray(dummyBoolean)).toBe(true);
     });
+  });
+});
+
+//
+// isObject
+//
+describe(`isObject`, () => {
+  test(`Object is evaluated`, () => {
+    const object = { foo: `foo`, bar: 1 };
+
+    expect(isObject(object)).toBe(true);
+  });
+
+  test(`String is evaluated`, () => {
+    const nonObject = `This is a string, not an object`;
+
+    expect(isObject(nonObject)).toBe(false);
+  });
+});
+
+//
+// extend
+//
+describe(`extend`, () => {
+  test(`Extending a deep object`, () => {
+    const object1 = { bar: { abc: `abc`, xyz: `xyz` }, foo: `foo` };
+    const object2 = { bar: { abc: `_new_abc` } };
+    const expected = { bar: { abc: `_new_abc`, xyz: `xyz` }, foo: `foo` };
+
+    expect(extend(object1, object2)).toEqual(expected);
+  });
+
+  test(`Extending flat object`, () => {
+    const object1 = { bar: `bar`, foo: 2 };
+    const object2 = { foo: 17 };
+    const expected = { bar: `bar`, foo: 17 };
+
+    expect(extend(object1, object2)).toEqual(expected);
   });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -98,3 +98,75 @@ export function getValueByPath(path, object, fallback) {
 
   return typeof value === `undefined` ? fallback : value;
 }
+
+/**
+ * @param {*} object
+ * @return {boolean}
+ */
+export function isObject(object) {
+  return object && typeof object === `object`;
+}
+
+/**
+ * @param {*} object
+ * @return {object}
+ */
+export function extend(...args) {
+  let options;
+  let src;
+  let copy;
+  let copyIsArray;
+  let clone;
+  let i = 1;
+  let target = args[0] || {};
+  const { length } = args;
+
+  function _extendBaseObject(name) {
+    src = target[name];
+    copy = options[name];
+
+    // Prevent never-ending loop
+    if (target === copy) {
+      return;
+    }
+
+    copyIsArray = Array.isArray(copy);
+
+    // Recurse if we're merging plain objects or arrays
+    if (copy && (isObject(copy) || copyIsArray)) {
+      if (copyIsArray) {
+        clone = src && Array.isArray(src) ? src : [];
+      } else {
+        clone = src && isObject(src) ? src : {};
+      }
+
+      // Do not move original objects, clone them
+      target[name] = extend(clone, copy);
+    } else if (copy !== undefined) {
+      target[name] = copy;
+    }
+  }
+
+  // Handle case when target is a string or something (possible in deep copy)
+  if (!isObject(target) && typeof target !== `function`) {
+    target = {};
+  }
+
+  if (i === length) {
+    target = this;
+    i -= 1;
+  }
+
+  for (; i < length; i += 1) {
+    // Only deal with non-null/undefined values
+    options = args[i];
+
+    if (typeof window !== `undefined` && options instanceof HTMLElement) {
+      target = options;
+    } else if (options != null) {
+      Object.keys(options).forEach(_extendBaseObject);
+    }
+  }
+
+  return target;
+}


### PR DESCRIPTION
## Description

If `propPathString` is: `'foo.data.foo'`, is the last `'foo'` what needs to be replaced to have a path like `['foo', 'data', '$foo']` instead of `['$foo', 'data', 'foo']`


## Related Issue

<!--- Use the format Fixes # -->

## Types of changes

- [ ] Build update
- [ ] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added and/or updated the tests, when applicable
- [x] I have added at least 1 reviewer to this PR (@quicoto or @rogercornet)
