### PR TITLE
feat: support groups of elements

### DIFF
--- a/develop/index.html
+++ b/develop/index.html
@@ -18,7 +18,7 @@
     <section id="welcome">
       <h1 data-custom-bind="site.general.heading">Non-JS heading</h1>
       <p data-custom-bind="site.general.description">Non-JS despcription</p>
-      <p><button id="log-state">Print state in console</button></p>
+      <p><button id="log-state">Print state</button></p>
     </section>
     <fieldset>
       <legend>Edit the texts</legend>
@@ -38,6 +38,21 @@
         <option value="cat">Cat</option>
       </select>
     </fieldset>
+    <fieldset>
+      <legend>Radiogroup</legend>
+      <p>You have selected: <span data-custom-bind="food"></span></p>
+      <input type="radio" id="food-pasta" name="food" value="pasta" data-custom-model="food" data-custom-bind="food">
+      <label for="food-pasta">Pasta</label>
+      <input type="radio" id="food-pizza" name="food" value="pizza" data-custom-model="food" data-custom-bind="food">
+      <label for="food-pizza">Pizza</label>
+      <input type="radio" id="food-risotto" name="food" value="risotto" data-custom-model="food" data-custom-bind="food">
+      <label for="food-risotto">Risotto</label>
+    </fieldset>
+
+    <input type="checkbox" id="permissions" name="permissions" data-custom-model="permissions" data-custom-bind="permissions">
+    <label for="permissions">Do you accept</label>
+    <br/>
+    <code id="print-area"></code>
   </main>
 </body>
 </html>

--- a/develop/index.js
+++ b/develop/index.js
@@ -4,10 +4,12 @@ const config = {
   attributeBind: `data-custom-bind`,
   attributeModel: `data-custom-model`,
   dataModel: {
+    food: `pasta`,
     pet: `cat`
   }
 };
 
+const printArea = document.querySelector(`#print-area`);
 const state = TwoWayDataBinding(config);
 
 document.addEventListener(`click`, (event) => {
@@ -18,8 +20,7 @@ document.addEventListener(`click`, (event) => {
   } else if (target.id === `change-description`) {
     state.site.general.description = target.dataset.text;
   } else if (target.id === `log-state`) {
-    // eslint-disable-next-line no-console
-    console.log(state.site);
+    printArea.textContent = JSON.stringify(state, null, `\t`);
   }
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,11 +23,37 @@ export default (config = {}) => {
   } = config;
   let _proxy;
 
+  /**
+   * @param {HTMLElement} $element
+   * @return {boolean}
+   */
+  function isCheckboxOrRadio($element) {
+    return $element.type === `checkbox` || $element.type === `radio`;
+  }
+
+  /**
+   * @param {HTMLElement} $element
+   * @return {boolean}
+   */
+  function isPartOfGroup($element) {
+    if ($element.name) {
+      const $elements = $context.querySelectorAll(`[name=${$element.name}]`);
+
+      return $elements.length > 1;
+    }
+
+    return false;
+  }
+
+  /**
+   * @param {HTMLElement} $element
+   * @return {string}
+   */
   function propertyToGet($element) {
     let propName = ``;
 
     if ($element.tagName === `INPUT`) {
-      if ($element.type === `checkbox` || $element.type === `radio`) {
+      if (isCheckboxOrRadio($element)) {
         propName = `checked`;
       } else {
         propName = `value`;
@@ -86,15 +112,20 @@ export default (config = {}) => {
 
     $elements.forEach(($element) => {
       if ($element.tagName === `INPUT`) {
-        if ($element.type === `checkbox` || $element.type === `radio`) {
-          let checked = value;
+        let checked = value !== `undefined` && value === ``;
 
-          // Make sure we're setting a boolean
-          if (typeof checked !== `boolean`) {
-            // Convert string to boolean
-            checked = value.toLowerCase() === `true`;
+        if (isCheckboxOrRadio($element)) {
+          if (isPartOfGroup($element)) {
+            checked = $element.value === value;
+          } else {
+            checked = value;
+
+            // Make sure we're setting a boolean
+            if (typeof checked !== `boolean`) {
+              // Convert string to boolean
+              checked = value.toLowerCase() === `true`;
+            }
           }
-
           $element.checked = checked;
         } else {
           $element.value = value;
@@ -136,7 +167,7 @@ export default (config = {}) => {
           const path = target.getAttribute(attributeModel).split(pathDelimiter);
 
           if (target.tagName === `INPUT`) {
-            if (target.type === `checkbox` || target.type === `radio`) {
+            if (isCheckboxOrRadio(target) && !isPartOfGroup(target)) {
               value = target.checked;
             }
           }

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -568,4 +568,56 @@ describe(`twoWayDataBinding`, () => {
 
     expect(proxy.pet).toEqual(`cat`);
   });
+
+  it(`Radiogroup via JS (data-bind)`, () => {
+    const {
+      container
+    } = render(
+      `<input type="radio" id="food-pasta" name="food" value="pasta" data-model="food" data-bind="food">
+      <label for="food-pasta">Pasta</label>
+      <input type="radio" id="food-pizza" name="food" value="pizza" data-model="food" data-bind="food">
+      <label for="food-pizza">Pizza</label>
+      <input type="radio" id="food-risotto" name="food" value="risotto" data-model="food" data-bind="food">
+      <label for="food-risotto">Risotto</label>`,
+      `data-bind`
+    );
+
+    twoWayDataBinding({
+      $context: container,
+      dataModel: {
+        food: `risotto`
+      }
+    });
+
+    const $element = container.querySelector(`[name="food"]:checked`);
+
+    expect($element.value).toEqual(`risotto`);
+  });
+
+  it(`Radiogroup via DOM (data-model)`, () => {
+    const {
+      container
+    } = render(
+      `<input type="radio" id="food-pasta" name="food" value="pasta" data-model="food" data-bind="food">
+      <label for="food-pasta">Pasta</label>
+      <input type="radio" id="food-pizza" name="food" value="pizza" data-model="food" data-bind="food">
+      <label for="food-pizza">Pizza</label>
+      <input type="radio" id="food-risotto" name="food" value="risotto" data-model="food" data-bind="food">
+      <label for="food-risotto">Risotto</label>`,
+      `data-bind`
+    );
+
+    const proxy = twoWayDataBinding({
+      $context: container,
+      dataModel: {}
+    });
+
+    const changeEvent = document.createEvent(`Event`);
+    const $element = container.querySelector(`[id="food-pizza"]`);
+
+    changeEvent.initEvent(`change`, true, true);
+    $element.dispatchEvent(changeEvent);
+
+    expect(proxy.food).toEqual(`pizza`);
+  });
 });


### PR DESCRIPTION
Groups of elements with the same name, eg: radiogroups are correctly handled. In those cases, model stores the `value` of the selected input (instead of true/false) and DOM also reflects the selected element

## Description

## Related Issue

<!--- Use the format Fixes # -->

## Types of changes

- [ ] Build update
- [ ] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added and/or updated the tests, when applicable
- [x] I have added at least 1 reviewer to this PR (@quicoto or @rogercornet)
