### PR TITLE
feat: dispatch custom event after set

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ Optional. Defines the attribute to bind to in your HTML. Defaults to `data-bind`
 
 Optional. Defines the attribute to bind to in your HTML. Defaults to `data-model`
 
+### `customEventPrefix`
+
+Optional. Defines the name of the custom event to be dispatched after it updates the state.
+
+```javascript
+$myInput.addEventListener('twowaydatabinding:change', () => {
+  // This will be fired after the native change, after we update the state
+});
+```
+
 ### `dataModel`
 
 Optional. Defines the data model. Defaults to `{}`

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {
  * @param {HTMLElement} [config.$context]
  * @param {string} [config.attributeBind]
  * @param {string} [config.attributeModel]
+ * @param {string} [config.customEventPrefix]
  * @param {object} [config.dataModel]
  * @param {string[]} [config.events]
  * @param {string} [config.pathDelimiter]
@@ -16,6 +17,7 @@ export default (config = {}) => {
     $context = document,
     attributeBind = `data-bind`,
     attributeModel = `data-model`,
+    customEventPrefix = `twowaydatabinding`,
     dataModel = {},
     domRefPrefix = `$`,
     events = [`keyup`, `change`],
@@ -160,10 +162,10 @@ export default (config = {}) => {
     events.forEach((eventName) => {
       $context.addEventListener(eventName, (DOMEvent) => {
         const { target } = DOMEvent;
+        const customEvent = document.createEvent(`Event`);
 
         if (target.hasAttribute(attributeModel)) {
           let { value } = target;
-
           const path = target.getAttribute(attributeModel).split(pathDelimiter);
 
           if (target.tagName === `INPUT`) {
@@ -173,6 +175,8 @@ export default (config = {}) => {
           }
 
           setValueByPath(value, path, _proxy);
+          customEvent.initEvent(`${customEventPrefix}:${eventName}`, true, true);
+          target.dispatchEvent(customEvent);
         }
       });
     });

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -620,4 +620,32 @@ describe(`twoWayDataBinding`, () => {
 
     expect(proxy.food).toEqual(`pizza`);
   });
+
+  it(`Custom Event is fired`, () => {
+    const {
+      container,
+      bindName
+    } = render(
+      `<input data-model="name" type="text" />`,
+      `data-bind`
+    );
+
+    twoWayDataBinding({
+      $context: container
+    });
+
+    const $input = bindName(`name`, `data-model`);
+    const changeEvent = document.createEvent(`Event`);
+    let customValue = false;
+
+    $input.addEventListener(`twowaydatabinding:change`, () => {
+      customValue = true;
+    });
+
+    changeEvent.initEvent(`change`, true, true);
+    $input.value = `Ricard`;
+    $input.dispatchEvent(changeEvent);
+
+    expect(customValue).toEqual(true);
+  });
 });


### PR DESCRIPTION
## Description

Fires a custom event after the native change or keyup.

## Types of changes

- [ ] Build update
- [ ] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added and/or updated the tests, when applicable
- [x] I have added at least 1 reviewer to this PR (@quicoto or @rogercornet)
