### PR TITLE
fix: avoid adding dom references to provided dataModel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,11 +16,11 @@ export default (config = {}) => {
     $context = document,
     attributeBind = `data-bind`,
     attributeModel = `data-model`,
-    dataModel = {},
     domRefPrefix = `$`,
     events = [`keyup`, `change`],
     pathDelimiter = `.`
   } = config;
+  const dataModel = { ...config.dataModel };
   let _proxy;
 
   /**


### PR DESCRIPTION
## Description
DOM refs like `$dataModelItem` are meant to be only in the returned `_proxy`. Create object from provided dataModel and affect that one instead of the one passed when initialising TwoWayDataBinding

## Types of changes
- [ ] Build update
- [ ] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added and/or updated the tests, when applicable
- [x] I have added at least 1 reviewer to this PR (@quicoto or @rogercornet)
