### PR TITLE
build: BREAKING CHANGE. customAttributes to prevent model being updated on every event

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,6 @@ Optional. Defines the attribute to bind to in your HTML. Defaults to `data-bind`
 
 Optional. Defines the attribute to bind to in your HTML. Defaults to `data-model`
 
-### `customEventPrefix`
-
-Optional. Defines the name of the custom event to be dispatched after it updates the state.
-
 ```javascript
 $myInput.addEventListener('twowaydatabinding:change', () => {
   // This will be fired after the native change, after we update the state
@@ -105,6 +101,41 @@ Optional. Defines the events to bind to. Defaults to ```[`keyup`, `change`]```
 ### `pathDelimiter`
 
 Optional. Defines the path delimiter in your `data-bind` attributes such as `header.site.name`. Defaults to `.`
+
+## Custom events handling
+
+In order to allow consumers to perform actions **after** TwoWayDataBinding performs model update, a custom event is fired with the name `twowaydatabinding:change|keyup|eventname`. By default is dispatched in `change` and `keyup` events, but it can be extended by setting more `events` in the array of the TwoWayDataBinding configuration, meaning a `twowaydatabinding:[eventname]` will be fired after the logic is executed, and the consumer application can subscribe to them to perform any needed logic after the library has done the operations.
+
+### <a id="setcustomvalue"></a>`twowaydatabinding:setcustomvalue`
+This event works the other way round, from the consumer application to TwoWayDataBinding, which is listening to that event and responds by setting in the data model the value passed for a given property.
+
+The library can prevent setting the value to the model for certain custom-value properties (see [attributeCustomValue](#attributecustomvalue)), and for those cases, a custom event `twowaydatabinding:setcustomvalue` can be fired in order to set a value into the model. A `twowaydatabinding:change` event is fired again after performing this action.
+
+To set the new value in the data model, dispatch the event in the correspondant element passing a `detail` object populated with `path` (property path of the property to change in the data model object) and `value` properties.
+
+To trigger it from your application:
+
+```javascript
+input.dispatchEvent(new CustomEvent(`twowaydatabinding:setcustomvalue`, {
+  bubbles: true,
+  cancelable: true,
+  detail: {
+    path: input.getAttribute(config.attributeModel),
+    value: dataValue
+  }
+}));
+
+proxy.propName // 'newValue'
+```
+
+## Setting a custom value to a bound input instead of his value in the data model
+### <a id="attributecustomvalue"></a>`attributeCustomValue`
+
+Optional. Defines an array of attributes to prevent the model being updated with the input value when `change` or `keyup` by default. Defaults to `['data-value']`.
+
+If an input has `data-model` and `data-bind` attributes at the same time, when this input value is changed, the model gets updated with that input `value` property. Nevertheless, this can be prevented by adding a custom attribute which will be the host of the actual value.
+
+By default is `['data-value']` (but can be customised and extended), and when an input has one of these attributes, the model is not updated with the value of the input and it should be manually updated by the consumer's application logic by dispatching a custom event `twowaydatabinding:setcustomvalue`. See [Custom Events handling](#setcustomvalue)
 
 ## Browser support
 

--- a/develop/index.html
+++ b/develop/index.html
@@ -52,6 +52,17 @@
     <input type="checkbox" id="permissions" name="permissions" data-custom-model="permissions" data-custom-bind="permissions">
     <label for="permissions">Do you accept</label>
     <br/>
+
+    <label for="country">Enter your country</label>
+    <input id="country" list="countries" data-custom-model="country" data-custom-bind="country" data-value>
+    <datalist id="countries">
+      <option data-value="ES">Spain (ES)</option>
+      <option data-value="US">United States (US)</option>
+      <option data-value="AR">Argentina (AR)</option>
+      <option data-value="DE">Germany (DE)</option>
+      <option data-value="BR">Brasil (BR)</option>
+    </datalist>
+    <br/>
     <code id="print-area"></code>
   </main>
 </body>

--- a/develop/index.js
+++ b/develop/index.js
@@ -23,6 +23,25 @@ document.addEventListener(`click`, (event) => {
     printArea.textContent = JSON.stringify(state, null, `\t`);
   }
 });
+document.addEventListener(`change`, (event) => {
+  const { target } = event;
+
+  if (target.id === `country`) {
+    const listName = target.getAttribute(`list`);
+    const $list = document.querySelector(`datalist#${listName}`);
+    const dataValue = Array
+      .from($list.options)
+      .find(($opt) => $opt.innerText === target.value)
+      .getAttribute(`data-value`);
+
+    target.setAttribute(`data-value`, dataValue);
+    target.dispatchEvent(new CustomEvent(`twowaydatabinding:setcustomvalue`, {
+      bubbles: true,
+      cancelable: true,
+      detail: { path: target.getAttribute(config.attributeModel), value: dataValue }
+    }));
+  }
+});
 
 setInterval(() => {
   // eslint-disable-next-line no-console

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -240,11 +240,9 @@ describe(`twoWayDataBinding`, () => {
 
     const element = bindName(`site.name`);
     const $input = bindName(`site.name`, `data-model`);
-    const changeEvent = document.createEvent(`Event`);
 
-    changeEvent.initEvent(`change`, true, true);
     $input.value = `Ricard`;
-    $input.dispatchEvent(changeEvent);
+    $input.dispatchEvent(new Event(`change`, { bubbles: true, cancelable: true }));
 
     expect($input).toHaveValue(`Ricard`);
     expect(element).toHaveTextContent(`Ricard`);
@@ -306,13 +304,10 @@ describe(`twoWayDataBinding`, () => {
       }
     });
 
-    const changeEvent = document.createEvent(`Event`);
     const $input = bindName(`name`);
 
     $input.value = `Ricard`;
-
-    changeEvent.initEvent(`change`, true, true);
-    $input.dispatchEvent(changeEvent);
+    $input.dispatchEvent(new Event(`change`, { bubbles: true, cancelable: true }));
 
     expect(proxy.name).toEqual(`Ricard`);
   });
@@ -370,12 +365,10 @@ describe(`twoWayDataBinding`, () => {
       $context: container
     });
 
-    const changeEvent = document.createEvent(`Event`);
     const $input = bindName(`areYouThor`);
 
-    changeEvent.initEvent(`change`, true, true);
     $input.checked = true;
-    $input.dispatchEvent(changeEvent);
+    $input.dispatchEvent(new Event(`change`, { bubbles: true, cancelable: true }));
 
     expect(proxy.areYouThor).toEqual(true);
   });
@@ -393,12 +386,10 @@ describe(`twoWayDataBinding`, () => {
       $context: container
     });
 
-    const changeEvent = document.createEvent(`Event`);
     const $input = bindName(`areYouThor`);
 
-    changeEvent.initEvent(`change`, true, true);
     $input.checked = false;
-    $input.dispatchEvent(changeEvent);
+    $input.dispatchEvent(new Event(`change`, { bubbles: true, cancelable: true }));
 
     expect(proxy.areYouThor).toEqual(false);
   });
@@ -504,12 +495,10 @@ describe(`twoWayDataBinding`, () => {
     });
 
     const $element = bindName(`myText`);
-    const changeEvent = document.createEvent(`Event`);
 
     $element.textContent = `New content`;
 
-    changeEvent.initEvent(`change`, true, true);
-    $element.dispatchEvent(changeEvent);
+    $element.dispatchEvent(new Event(`change`, { bubbles: true, cancelable: true }));
 
     expect(proxy.myText).toEqual(`New content`);
   });
@@ -559,12 +548,9 @@ describe(`twoWayDataBinding`, () => {
     });
 
     const $element = bindName(`pet`);
-    const changeEvent = document.createEvent(`Event`);
 
     $element.value = `cat`;
-
-    changeEvent.initEvent(`change`, true, true);
-    $element.dispatchEvent(changeEvent);
+    $element.dispatchEvent(new Event(`change`, { bubbles: true, cancelable: true }));
 
     expect(proxy.pet).toEqual(`cat`);
   });
@@ -612,11 +598,9 @@ describe(`twoWayDataBinding`, () => {
       dataModel: {}
     });
 
-    const changeEvent = document.createEvent(`Event`);
     const $element = container.querySelector(`[id="food-pizza"]`);
 
-    changeEvent.initEvent(`change`, true, true);
-    $element.dispatchEvent(changeEvent);
+    $element.dispatchEvent(new Event(`change`, { bubbles: true, cancelable: true }));
 
     expect(proxy.food).toEqual(`pizza`);
   });
@@ -635,17 +619,57 @@ describe(`twoWayDataBinding`, () => {
     });
 
     const $input = bindName(`name`, `data-model`);
-    const changeEvent = document.createEvent(`Event`);
     let customValue = false;
 
     $input.addEventListener(`twowaydatabinding:change`, () => {
       customValue = true;
     });
 
-    changeEvent.initEvent(`change`, true, true);
     $input.value = `Ricard`;
-    $input.dispatchEvent(changeEvent);
+    $input.dispatchEvent(new Event(`change`, { bubbles: true, cancelable: true }));
 
     expect(customValue).toEqual(true);
+  });
+
+  it(`Element with custom value attribute [data-value]`, () => {
+    const {
+      container,
+      bindName
+    } = render(
+      `<input data-model="country" data-bind="country" data-value="ES" type="text" />`,
+      `data-bind`
+    );
+
+    const proxy = twoWayDataBinding({
+      $context: container
+    });
+
+    const $input = bindName(`country`, `data-model`);
+
+    $input.value = `Spain (ES)`;
+    $input.dispatchEvent(new Event(`change`, { bubbles: true, cancelable: true }));
+
+    expect(proxy.country).toEqual(`ES`);
+  });
+
+  it(`Element with custom value attribute [data-value]`, () => {
+    const {
+      container,
+      bindName
+    } = render(
+      `<input data-model="country" data-bind="country" data-value="ES" type="text" />`,
+      `data-bind`
+    );
+
+    const proxy = twoWayDataBinding({
+      $context: container
+    });
+
+    const $input = bindName(`country`, `data-model`);
+
+    $input.value = `Spain (ES)`;
+    $input.dispatchEvent(new Event(`change`, { bubbles: true, cancelable: true }));
+
+    expect(proxy.country).toEqual(`ES`);
   });
 });


### PR DESCRIPTION
inputs with data-model, data-bind and data-value (or configured attributesCustomValue array) are not updating the model with its value on every event. For those cases, the model needs to be updated manually by dispatching `twowaydatabinding:setcustomvalue` and passing `{ detail: { path: path, value: value } }`

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added and/or updated the tests, when applicable
- [x] I have added at least 1 reviewer to this PR (@quicoto or @rogercornet)
