### PR TITLE
feat: set custom attribute and the value on setting value to proxy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,13 @@ export default (config = {}) => {
     if (typeof $elements === `undefined` || value === null) return;
 
     $elements.forEach(($element) => {
-      if (hasCustomValue($element)) return;
+      if (hasCustomValue($element)) {
+        const attr = propertyToGet($element);
+
+        $element.setAttribute(attr, value);
+
+        return;
+      }
 
       if ($element.tagName === `INPUT`) {
         let checked = value !== `undefined` && value === ``;

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -651,4 +651,25 @@ describe(`twoWayDataBinding`, () => {
 
     expect(proxy.country).toEqual(`ES`);
   });
+
+  it(`Update element via proxy with custom value attribute [data-twowayvalue]`, () => {
+    const {
+      container,
+      bindName
+    } = render(
+      `<input data-model="country" data-bind="country" data-twowayvalue="ES" type="text" value="Spain (ES)" />`,
+      `data-bind`
+    );
+
+    const proxy = twoWayDataBinding({
+      $context: container,
+      attributesCustomValue: [`data-twowayvalue`]
+    });
+    const $input = bindName(`country`, `data-model`);
+
+    proxy.country = `Germany (DE)`;
+
+    expect($input.getAttribute(`data-twowayvalue`)).toEqual(`Germany (DE)`);
+    expect($input.value).toEqual(`Spain (ES)`);
+  });
 });


### PR DESCRIPTION
## Description
When a proxy property gets updated, the new value gets reflected in the custom data-attribute bound to that element

## Types of changes

- [ ] Build update
- [ ] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have added and/or updated the tests, when applicable
- [x] I have added at least 1 reviewer to this PR (@quicoto or @rogercornet)
